### PR TITLE
Add S-PWM Algorithm

### DIFF
--- a/LED_Matrix/CMakeLists.txt
+++ b/LED_Matrix/CMakeLists.txt
@@ -30,6 +30,7 @@ set(DEFINE_SERIAL_RGB_TYPE "RGB24" CACHE STRING "RGB type name")
 set(DEFINE_MULTIPLEX_SCAN "8" CACHE STRING "Panel scan")
 set(DEFINE_COLUMNS "32" CACHE STRING "Shift chain length")
 set(DEFINE_MAX_RGB_LED_STEPS "130" CACHE STRING "Min constrast of LED without multiplexing")
+set(DEFINE_S_PWM_SEG "4" CACHE STRING "Number of bits per S-PWM segment")
 
 # These determine timing and state machine settings at compile time
 set(DEFINE_MATRIX_DCLOCK "17.0" CACHE STRING "Matrix serial clock speed in MHz")

--- a/LED_Matrix/include/Matrix/CMakeLists.txt
+++ b/LED_Matrix/include/Matrix/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(BCM)
 add_subdirectory(PWM)
+add_subdirectory(S_PWM)
 
 configure_file(config.h.in config.h @ONLY)

--- a/LED_Matrix/include/Matrix/S_PWM/CMakeLists.txt
+++ b/LED_Matrix/include/Matrix/S_PWM/CMakeLists.txt
@@ -1,0 +1,1 @@
+configure_file(memory_format.h.in memory_format.h @ONLY)

--- a/LED_Matrix/include/Matrix/S_PWM/memory_format.h.in
+++ b/LED_Matrix/include/Matrix/S_PWM/memory_format.h.in
@@ -1,0 +1,44 @@
+/* 
+ * File:   memory_format.h
+ * Author: David Thacher
+ * License: GPL 3.0
+ */
+ 
+#ifndef MEMORY_FORMAT_H
+#define MEMORY_FORMAT_H
+
+#include <stdint.h>
+#include <math.h>
+#include <algorithm>
+#include "Matrix/config.h"
+
+namespace Matrix {
+    // -- DO NOT EDIT BELOW THIS LINE --
+
+    #cmakedefine DEFINE_MAX_RGB_LED_STEPS   @DEFINE_MAX_RGB_LED_STEPS@
+    #cmakedefine DEFINE_MIN_REFRESH         @DEFINE_MIN_REFRESH@
+    #cmakedefine DEFINE_MATRIX_DCLOCK       @DEFINE_MATRIX_DCLOCK@
+    #cmakedefine DEFINE_BLANK_TIME          @DEFINE_BLANK_TIME@
+    #cmakedefine DEFINE_FPS                 @DEFINE_FPS@
+    #cmakedefine DEFINE_BYPASS_FANOUT       @DEFINE_BYPASS_FANOUT@
+    #cmakedefine DEFINE_S_PWM_SEG           @DEFINE_S_PWM_SEG@
+
+    #ifndef DEFINE_BYPASS_FANOUT
+    #define DEFINE_BYPASS_FANOUT            false
+    #endif
+    
+    constexpr uint16_t MAX_RGB_LED_STEPS = DEFINE_MAX_RGB_LED_STEPS;       // Contrast Ratio - Min RGB constant forward current (Blue LED in my case) in uA divided by min light current in uA
+    constexpr uint16_t MIN_REFRESH = DEFINE_MIN_REFRESH;
+    constexpr double SERIAL_CLOCK = (DEFINE_MATRIX_DCLOCK * 1000000.0);
+    constexpr uint8_t BLANK_TIME = DEFINE_BLANK_TIME;
+    constexpr uint8_t FPS = DEFINE_FPS;
+    constexpr bool BYPASS_FANOUT = DEFINE_BYPASS_FANOUT;
+    constexpr uint8_t S_PWM_SEG = DEFINE_S_PWM_SEG;
+    
+    constexpr uint8_t PWM_bits = std::max(round(log2((double) MAX_RGB_LED_STEPS / MULTIPLEX)), S_PWM_SEG);
+    
+    typedef volatile uint8_t test2[MULTIPLEX][1 << (PWM_bits - S_PWM_SEG)][1 << S_PWM_SEG][COLUMNS + 1];
+}
+
+#endif
+

--- a/LED_Matrix/include/Matrix/S_PWM/memory_format.h.in
+++ b/LED_Matrix/include/Matrix/S_PWM/memory_format.h.in
@@ -35,7 +35,7 @@ namespace Matrix {
     constexpr bool BYPASS_FANOUT = DEFINE_BYPASS_FANOUT;
     constexpr uint8_t S_PWM_SEG = DEFINE_S_PWM_SEG;
     
-    constexpr uint8_t PWM_bits = std::max(round(log2((double) MAX_RGB_LED_STEPS / MULTIPLEX)), S_PWM_SEG);
+    constexpr uint8_t PWM_bits = std::max((uint8_t) round(log2((double) MAX_RGB_LED_STEPS / MULTIPLEX)), S_PWM_SEG);
     constexpr uint8_t upper_bits = PWM_bits - S_PWM_SEG;
     constexpr uint8_t lower_bits = S_PWM_SEG;
     

--- a/LED_Matrix/include/Matrix/S_PWM/memory_format.h.in
+++ b/LED_Matrix/include/Matrix/S_PWM/memory_format.h.in
@@ -36,6 +36,8 @@ namespace Matrix {
     constexpr uint8_t S_PWM_SEG = DEFINE_S_PWM_SEG;
     
     constexpr uint8_t PWM_bits = std::max(round(log2((double) MAX_RGB_LED_STEPS / MULTIPLEX)), S_PWM_SEG);
+    constexpr uint8_t upper_bits = PWM_bits - S_PWM_SEG;
+    constexpr uint8_t lower_bits = S_PWM_SEG;
     
     typedef volatile uint8_t test2[MULTIPLEX][1 << (PWM_bits - S_PWM_SEG)][1 << S_PWM_SEG][COLUMNS + 1];
 }

--- a/LED_Matrix/lib/Matrix/BCM/calculator.cpp
+++ b/LED_Matrix/lib/Matrix/BCM/calculator.cpp
@@ -54,6 +54,12 @@ namespace Matrix::Calculator {
         is_clk_valid();
         is_blank_time_valid();
         
+        static_assert(COLUMNS >= 8, "COLUMNS less than 8 is not recommended");
+        static_assert(COLUMNS <= 256, "COLUMNS more than 1024 is not recommended, but we only support up to 256");
+        static_assert((2 * MULTIPLEX * COLUMNS) <= 8192, "More than 8192 pixels is not recommended");
+        static_assert((2 * MULTIPLEX * COLUMNS * sizeof(Serial::DEFINE_SERIAL_RGB_TYPE)) <= (12 * 1024), "The current frame size is not supported");
+        static_assert((MULTIPLEX * COLUMNS * (PWM_bits)) <= (48 * 1024), "The current buffer size is not supported");
+        static_assert((MULTIPLEX * (1 << PWM_bits)) <= (4 * 1024), "The current LED grayscale is not supported");
         static_assert(MIN_REFRESH > 2 * FPS, "Refresh rate must be higher than twice the number of frames per second");
     }
 }

--- a/LED_Matrix/lib/Matrix/BCM/matrix.cpp
+++ b/LED_Matrix/lib/Matrix/BCM/matrix.cpp
@@ -111,13 +111,6 @@ namespace Matrix {
         static_assert(x >= 1.0, "Unabled to configure PIO for SERIAL_CLOCK");
 
         Calculator::verify_configuration();
-        
-        static_assert(COLUMNS >= 8, "COLUMNS less than 8 is not recommended");
-        static_assert(COLUMNS <= 256, "COLUMNS more than 1024 is not recommended, but we only support up to 256");
-        static_assert((2 * MULTIPLEX * COLUMNS) <= 8192, "More than 8192 pixels is not recommended");
-        static_assert((2 * MULTIPLEX * COLUMNS * sizeof(Serial::DEFINE_SERIAL_RGB_TYPE)) <= (12 * 1024), "The current frame size is not supported");
-        static_assert((MULTIPLEX * COLUMNS * (PWM_bits)) <= (48 * 1024), "The current buffer size is not supported");
-        static_assert((MULTIPLEX * (1 << PWM_bits)) <= (4 * 1024), "The current LED grayscale is not supported");
 
         // PMP / SM
         pio0->sm[0].clkdiv = ((uint32_t) floor(x) << 16) | ((uint32_t) round((x - floor(x)) * 255.0) << 8);

--- a/LED_Matrix/lib/Matrix/CMakeLists.txt
+++ b/LED_Matrix/lib/Matrix/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(BCM)
 add_subdirectory(PWM)
+add_subdirectory(S_PWM)
 add_subdirectory(Test)

--- a/LED_Matrix/lib/Matrix/S_PWM/CMakeLists.txt
+++ b/LED_Matrix/lib/Matrix/S_PWM/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Since we use preprocessor we have to use interface library
+#   Optimization likely destroys any point in making this an actual lib
+
+add_library(led_S_PWM INTERFACE)
+
+target_sources(led_S_PWM INTERFACE
+    matrix.cpp
+    worker.cpp
+    calculator.cpp
+)
+
+target_link_libraries(led_S_PWM INTERFACE
+    pico_multicore
+    hardware_dma
+    hardware_pio
+    hardware_timer
+)

--- a/LED_Matrix/lib/Matrix/S_PWM/README.md
+++ b/LED_Matrix/lib/Matrix/S_PWM/README.md
@@ -1,0 +1,16 @@
+# S_PWM Documentation
+This implements the S_PWM Matrix Algorithm for standard (GEN 1) LED Panels. This does not use binary coded modulation (BCM) or bit angle modulation (BAM).
+
+## Status
+This is believed to be in working order, however testing did not cover all aspects.
+
+## Overview
+This will generate a single on time within the PWM period. This requires more computation and is not supported for all panel sizes and color depth configurations.
+
+This is believed to matter for higher refresh rates as the panels have some low pass filters built into them. These filters will corrupt the duty cycle within the PWM period. The effect is potentially larger with the BCM Matrix Algorithm.
+
+## Interrupts
+Follows standard design for Matrix Algorithms.
+
+## Core reservations
+Follows standard design for Matrix Algorithms.

--- a/LED_Matrix/lib/Matrix/S_PWM/calculator.cpp
+++ b/LED_Matrix/lib/Matrix/S_PWM/calculator.cpp
@@ -2,6 +2,7 @@
 #include <stdint.h>
 #include "Matrix/S_PWM/memory_format.h"
 #include "Matrix/matrix.h"
+#include "Serial/config.h"
 
 namespace Matrix::Calculator {
     // Panel constants
@@ -53,6 +54,30 @@ namespace Matrix::Calculator {
         is_brightness_valid();
         is_clk_valid();
         is_blank_time_valid();
+
+        // This could be 8 or 16 depending on panel. (Kind of random.)
+        static_assert(COLUMNS >= 8, "COLUMNS less than 8 is not recommended");
+
+        // This is depends on panel implementation however the fanout and par cap in matrix limit the max size.
+        //  Technically capable of more pixels with multiplexing, if we reduce refresh and contrast.
+        //  Picked numbers to simplify support and define limits.
+        static_assert(COLUMNS <= 256, "COLUMNS more than 1024 is not recommended, but we only support up to 256");
+        static_assert((2 * MULTIPLEX * COLUMNS) <= 8192, "More than 8192 pixels is not recommended");
+
+        // This is the limit observed in testing and from most panel specifications.
+        static_assert((MULTIPLEX * (1 << PWM_bits)) <= (4 * 1024), "The current LED grayscale is not supported");
+
+        // There is a trade off here: (Is most extreme for this matrix algorithm.)
+        //  1. Increase the frame size and do remote computation. (This works up to 96KB, which requires at least 25Mbps in serial algorithm.)
+        //      Currently this is not used and set to 12KB, which requires at least 7.8Mbps in serial algorithm. (Local CPU is used to compute bitplanes.)
+        //          Note 7.8Mbps allows for main processor jitter and 30 frames per second. (7.8Mbps reduces termination complexity.)
+        //  2. Use local computation which constrains the buffer size. (This works up to 48KB, which requires all of core 1.)
+        //      Currently this is used and is constrained to 48KB, which requires all of core 1.
+        //
+        //  The sum off all memory usage for serial frames and LED buffers must not exceed 192KB.
+        //      64KB is reserved for code and 8KB is reserved for stack/heap for both cores.
+        static_assert((2 * MULTIPLEX * COLUMNS * sizeof(Serial::DEFINE_SERIAL_RGB_TYPE)) <= (12 * 1024), "The current frame size is not supported");
+        static_assert((MULTIPLEX * COLUMNS * (1 << PWM_bits)) <= (48 * 1024), "The current buffer size is not supported");
 
         static_assert(MIN_REFRESH / (1 << (PWM_bits - S_PWM_SEG)) > 2, "Refresh rate too low to support the current S_PWM segment size for the selected LED contrast");
         static_assert(MIN_REFRESH > 2 * FPS, "Refresh rate must be higher than twice the number of frames per second");

--- a/LED_Matrix/lib/Matrix/S_PWM/calculator.cpp
+++ b/LED_Matrix/lib/Matrix/S_PWM/calculator.cpp
@@ -1,0 +1,60 @@
+#include <algorithm>
+#include <stdint.h>
+#include "Matrix/S_PWM/memory_format.h"
+#include "Matrix/matrix.h"
+
+namespace Matrix::Calculator {
+    // Panel constants
+    constexpr double max_clk_mhz = 25.0;
+    constexpr uint8_t columns_per_driver = 16;
+    constexpr uint8_t fanout_per_clk = 6;
+    constexpr uint8_t max_impedance = 50;               // For longer chains may need custom circuit board which adjusts this
+    constexpr uint8_t max_par_cap_pf = 18;              // For longer chains may need custom circuit board which adjusts this
+    constexpr uint8_t min_harmonics = 5;
+
+    // LED constants
+    constexpr uint16_t max_led_impedance = 1650;
+    constexpr uint8_t max_led_cap_pf = 18;
+    constexpr uint8_t min_led_harmonics = 5;
+
+    static constexpr double get_refresh_overhead() {
+        double refresh_overhead = 1000000.0 / (MULTIPLEX * MIN_REFRESH);
+        refresh_overhead /= refresh_overhead - BLANK_TIME;
+        return refresh_overhead;
+    }
+
+    static constexpr void is_clk_valid() {
+        constexpr uint64_t temp = (COLUMNS / columns_per_driver) * max_impedance * fanout_per_clk * min_harmonics * max_par_cap_pf;
+        constexpr double hz_limit = BYPASS_FANOUT ? max_clk_mhz * 1000000.0 : 
+            std::min(max_clk_mhz, (double) (1000000.0 / (temp * 1.0))) * 1000000.0;
+        constexpr double clk_hz = hz_limit / (MIN_REFRESH * get_refresh_overhead() * COLUMNS * MULTIPLEX * (1 << S_PWM_SEG));
+        
+        static_assert(SERIAL_CLOCK <= hz_limit, "Serial clock is too high");
+        static_assert(clk_hz >= 1.0, "Configuration is not possible");
+    }
+
+    static constexpr void is_brightness_valid() {
+        constexpr double led_rise_us = (max_led_impedance * min_led_harmonics * max_led_cap_pf * MULTIPLEX) / 1000000.0;
+        constexpr double period_us = 1000000.0 / (MIN_REFRESH * MULTIPLEX);
+        constexpr double brightness = ((period_us / get_refresh_overhead()) - led_rise_us) / period_us;
+        constexpr double accuracy = ((period_us / get_refresh_overhead()) - led_rise_us) / (period_us / get_refresh_overhead());
+
+        static_assert(brightness > 0.75, "Brightness less than 75 percent is not recommended");
+        static_assert(accuracy > 0.95, "Accuracy less than 95 percent is not recommended");
+    }
+
+    static constexpr void is_blank_time_valid() {
+        constexpr double led_fall_us_high = (10000 * COLUMNS * max_led_cap_pf) / 1000000.0;
+
+        static_assert(led_fall_us_high < BLANK_TIME, "Blank time is too low for high side");
+    }
+
+    void verify_configuration() {
+        is_brightness_valid();
+        is_clk_valid();
+        is_blank_time_valid();
+
+        static_assert(MIN_REFRESH / (1 << (PWM_bits - S_PWM_SEG)) > 2, "Refresh rate too low to support the current S_PWM segment size for the selected LED contrast");
+        static_assert(MIN_REFRESH > 2 * FPS, "Refresh rate must be higher than twice the number of frames per second");
+    }
+}

--- a/LED_Matrix/lib/Matrix/S_PWM/matrix.cpp
+++ b/LED_Matrix/lib/Matrix/S_PWM/matrix.cpp
@@ -1,0 +1,244 @@
+/* 
+ * File:   matrix.cpp
+ * Author: David Thacher
+ * License: GPL 3.0
+ */
+ 
+#include <stdint.h>
+#include <string.h>
+#include "pico/platform.h"
+#include "hardware/pio.h"
+#include "hardware/gpio.h"
+#include "hardware/dma.h"
+#include "hardware/timer.h"
+#include "hardware/structs/bus_ctrl.h"
+#include "Matrix/config.h"
+#include "Matrix/matrix.h"
+#include "Matrix/S_PWM/memory_format.h"
+#include "Multiplex/Multiplex.h"
+#include "Serial/config.h"
+
+namespace Matrix::Worker {
+    extern volatile bool vsync;
+}
+
+namespace Matrix {
+    test2 buf[3];
+    static uint8_t bank = 0;
+    static volatile uint8_t state = 0;
+    static int dma_chan[2];
+    static volatile struct {volatile uint32_t len; volatile uint8_t *data;} address_table[(1 << PWM_bits) + 2];
+    static volatile uint8_t null_table[COLUMNS + 1];
+    volatile int timer;
+
+    static void send_line();
+    static void load_line(uint8_t rows, uint8_t seg, uint8_t buffer);
+
+    /*
+        There are 2^PWM_bits + 1 shifts per period.
+        The last shift turns the columns off before multiplexing.
+
+        The serial protocol used by PIO is column length decremented by one followed by column values.
+    */
+
+    void start() {
+        // Init Matrix hardware
+        // IO
+        for (int i = 0; i < 8; i++) {
+            gpio_init(i + 8);
+            gpio_set_dir(i + 8, GPIO_OUT);
+        }
+        for (int i = 0; i < 8; i++)
+            gpio_set_function(i + 8, GPIO_FUNC_PIO0);
+        gpio_init(22);
+        gpio_set_dir(22, GPIO_OUT);
+        gpio_clr_mask(0x40FF00);
+
+        Multiplex::init(MULTIPLEX);
+        
+        memset((void *) buf, COLUMNS - 1, sizeof(buf));
+        memset((void *) null_table, 0, COLUMNS + 1);
+        null_table[0] = COLUMNS - 1;
+
+        for (uint32_t i = 0; i < (1 << PWM_bits); i++)
+            address_table[i].len = COLUMNS + 1;
+
+        address_table[1 << PWM_bits].data = null_table;
+        address_table[1 << PWM_bits].len = COLUMNS + 1;
+        address_table[(1 << PWM_bits) + 1].data = NULL;
+        address_table[(1 << PWM_bits) + 1].len = 0;
+        
+        // Hack to lower the ISR tick rate, accelerates by 2^PWM_bits (Improves refresh performance)
+        //  Automates CLK and LAT signals with DMA and PIO to handle Software PWM of entire row
+        //      Works like Hardware PWM without the high refresh
+        //      This is more or less how it would work with MACHXO2 FPGA and PIC32MX using PMP.
+        //          Bus performance is better with RP2040. (Lower cost due to memory, CPU, hardware integration.)
+        //  OE is not used in this implementation and held to low to enable the display
+        //      Last shift will disable display.
+        /*while (1) {
+            counter2 = (1 << PWM_bits) - 1; LAT = 0;    // Start of frame, manually push into FIFO (data stream protocol)
+            do {
+                counter = COLUMNS - 1;                  // Start of payload, DMA push into FIFO (data stream protocol)
+                do {
+                    DAT = DATA; CLK = 0;                // Payload data, DMA push into FIFO (data stream protocol)
+                    CLK = 1;                            // Automate CLK pulse
+                } while (counter-- > 0); CLK = 0;
+                LAT = 1;                                // Automate LAT pulse at end of payload (bitplane shift)
+                LAT = 0;
+            } while (counter2-- > 0);
+            IRQ = 1;                                    // Call CPU at end of frame
+        }*/
+    
+        // PIO
+        const uint16_t instructions[] = {
+            (uint16_t) (pio_encode_pull(false, true) | pio_encode_sideset(2, 0)),   // PIO SM
+            (uint16_t) (pio_encode_out(pio_x, 8) | pio_encode_sideset(2, 0)),
+            (uint16_t) (pio_encode_out(pio_y, 8) | pio_encode_sideset(2, 0)),
+            (uint16_t) (pio_encode_out(pio_pins, 6) | pio_encode_sideset(2, 0)),    // PMP Program
+            (uint16_t) (pio_encode_jmp_y_dec(3) | pio_encode_sideset(2, 1)),
+            (uint16_t) (pio_encode_nop() | pio_encode_sideset(2, 2)),
+            (uint16_t) (pio_encode_nop() | pio_encode_sideset(2, 2)),
+            (uint16_t) (pio_encode_nop() | pio_encode_sideset(2, 0)),
+            (uint16_t) (pio_encode_jmp_x_dec(2) | pio_encode_sideset(2, 0)),
+            (uint16_t) (pio_encode_jmp(0) | pio_encode_sideset(2, 0))
+        };
+        static const struct pio_program pio_programs = {
+            .instructions = instructions,
+            .length = count_of(instructions),
+            .origin = 0,
+        };
+        pio_add_program(pio0, &pio_programs);
+        pio_sm_set_consecutive_pindirs(pio0, 0, 8, 8, true);
+        
+        // Verify Serial Clock
+        constexpr float x = 125000000.0 / (SERIAL_CLOCK * 2.0);
+        static_assert(x >= 1.0, "Unabled to configure PIO for SERIAL_CLOCK");
+
+        Calculator::verify_configuration();
+
+        // This could be 8 or 16 depending on panel. (Kind of random.)
+        static_assert(COLUMNS >= 8, "COLUMNS less than 8 is not recommended");
+
+        // This is depends on panel implementation however the fanout and par cap in matrix limit the max size.
+        //  Technically capable of more pixels with multiplexing, if we reduce refresh and contrast.
+        //  Picked numbers to simplify support and define limits.
+        static_assert(COLUMNS <= 256, "COLUMNS more than 1024 is not recommended, but we only support up to 256");
+        static_assert((2 * MULTIPLEX * COLUMNS) <= 8192, "More than 8192 pixels is not recommended");
+
+        // This is the limit observed in testing and from most panel specifications.
+        static_assert((MULTIPLEX * (1 << PWM_bits)) <= (4 * 1024), "The current LED grayscale is not supported");
+
+        // There is a trade off here: (Is most extreme for this matrix algorithm.)
+        //  1. Increase the frame size and do remote computation. (This works up to 96KB, which requires at least 25Mbps in serial algorithm.)
+        //      Currently this is not used and set to 12KB, which requires at least 7.8Mbps in serial algorithm. (Local CPU is used to compute bitplanes.)
+        //          Note 7.8Mbps allows for main processor jitter and 30 frames per second. (7.8Mbps reduces termination complexity.)
+        //  2. Use local computation which constrains the buffer size. (This works up to 48KB, which requires all of core 1.)
+        //      Currently this is used and is constrained to 48KB, which requires all of core 1.
+        //
+        //  The sum off all memory usage for serial frames and LED buffers must not exceed 192KB.
+        //      64KB is reserved for code and 8KB is reserved for stack/heap for both cores.
+        static_assert((2 * MULTIPLEX * COLUMNS * sizeof(Serial::DEFINE_SERIAL_RGB_TYPE)) <= (12 * 1024), "The current frame size is not supported");
+        static_assert((MULTIPLEX * COLUMNS * (1 << PWM_bits)) <= (48 * 1024), "The current buffer size is not supported");
+
+        // PMP / SM
+        pio0->sm[0].clkdiv = ((uint32_t) floor(x) << 16) | ((uint32_t) round((x - floor(x)) * 255.0) << 8);
+        pio0->sm[0].pinctrl = (2 << PIO_SM0_PINCTRL_SIDESET_COUNT_LSB) | (6 << PIO_SM0_PINCTRL_OUT_COUNT_LSB) | (14 << PIO_SM0_PINCTRL_SIDESET_BASE_LSB) | 8;
+        pio0->sm[0].shiftctrl = (1 << PIO_SM0_SHIFTCTRL_AUTOPULL_LSB) | (6 << 25) | (1 << 19);
+        pio0->sm[0].execctrl = (1 << 17) | (12 << 12);
+        pio0->sm[0].instr = pio_encode_jmp(0);
+        hw_set_bits(&pio0->ctrl, 1 << PIO_CTRL_SM_ENABLE_LSB);
+        pio_sm_claim(pio0, 0);
+        
+        // DMA
+        bus_ctrl_hw->priority = (1 << 12) | (1 << 8);
+        dma_chan[0] = dma_claim_unused_channel(true);
+        dma_chan[1] = dma_claim_unused_channel(true);
+        dma_channel_config c = dma_channel_get_default_config(dma_chan[0]);
+        channel_config_set_transfer_data_size(&c, DMA_SIZE_8);
+        channel_config_set_read_increment(&c, true);
+        channel_config_set_dreq(&c, DREQ_PIO0_TX0);
+        channel_config_set_chain_to(&c, dma_chan[1]);
+        channel_config_set_irq_quiet(&c, true);
+        dma_channel_configure(dma_chan[0], &c, &pio0_hw->txf[0], NULL, 0, false);
+        dma_channel_set_irq0_enabled(dma_chan[0], true); 
+        
+        c = dma_channel_get_default_config(dma_chan[1]);
+        channel_config_set_transfer_data_size(&c, DMA_SIZE_32);
+        channel_config_set_read_increment(&c, true);
+        channel_config_set_write_increment(&c, true);
+        channel_config_set_ring(&c, true, 3);                                       // 1 << 3 byte boundary on write ptr
+        dma_channel_configure(dma_chan[1], &c, &dma_hw->ch[dma_chan[0]].al3_transfer_count, &address_table[0], 2, false);
+
+        timer = hardware_alarm_claim_unused(true);
+        timer_hw->inte |= 1 << timer;
+        
+        load_line(0, 0, 1);
+        send_line();
+    }
+
+    void __not_in_flash_func(send_line)() {
+        dma_hw->ints0 = 1 << dma_chan[0];
+        pio_sm_put(pio0, 0, 1 << PWM_bits);
+        dma_channel_set_read_addr(dma_chan[1], &address_table[0], true);
+    }
+
+    // This is done to reduce interrupt rate. Use DMA to automate the PWM bitplanes instead of CPU.
+    //  This is possible due to PIO state machine.
+    void __not_in_flash_func(load_line)(uint8_t rows, uint8_t seg, uint8_t buffer) {
+        for (uint32_t i = 0; i < (1 << S_PWM_SEG); i++)
+                address_table[i].data = buf[buffer][rows][seg][i];
+    }
+
+    void __not_in_flash_func(dma_isr)() {
+        if (dma_channel_get_irq0_status(dma_chan[0])) {      
+            // Make sure the FIFO is empty 
+            //  There was a bug with LAT when SERIAL_CLOCK is small, but I forgot what it was. (Just counted out additional time as hack.)
+            constexpr uint32_t FIFO_delay = (uint32_t) 125000000U / ((uint32_t) round(SERIAL_CLOCK) / 5 * 1000);
+            timer_hw->alarm[timer] = time_us_32() + FIFO_delay + 1;                 // Load timer
+            timer_hw->armed = 1 << timer;                                           // Kick off timer
+            state = 0;
+            dma_hw->intr = 1 << dma_chan[0];                                        // Clear the interrupt
+        }
+    }
+
+    void __not_in_flash_func(timer_isr)() {
+        static uint8_t rows = 0;
+        static uint8_t seg = 0;
+
+        if (timer_hw->ints & (1 << timer)) {                                        // Verify who called this
+            switch(state) {
+                case 0:
+                    gpio_set_mask(1 << 22);                                                 // Turn off the panel (For MBI5124 this activates the low side anti-ghosting)
+                    timer_hw->alarm[timer] = time_us_32() + BLANK_TIME + 1;                 // Load timer
+                    timer_hw->armed = 1 << timer;                                           // Kick off timer
+                    
+                    if (++rows >= MULTIPLEX) {                                              // Fire rate: MULTIPLEX * REFRESH (Note we now call 3 ISRs per fire)
+                        rows = 0;
+                        
+                        if (++seg >= 1 << S_PWM_SEG)
+                            seg = 0;
+
+                        if (Worker::vsync) {
+                            bank = (bank + 1) % 3;
+                            Worker::vsync = false;
+                            seg = 0;
+                        }
+                    }
+
+                    Multiplex::SetRow(rows);
+                    load_line(rows, seg, bank);                                             // Note this is a fairly expensive operation. This is done in parallel with blank time.
+                    state++;
+                    break;
+                case 1:
+                    gpio_clr_mask(1 << 22);                                         // Turn on the panel (Note software controls PWM/BCM)
+                    send_line();                                                    // Kick off hardware
+                    state++;
+                    break;
+                default:
+                    break;
+            }
+            
+            timer_hw->intr = 1 << timer;                                            // Clear the interrupt
+        }
+    }
+}

--- a/LED_Matrix/lib/Matrix/S_PWM/matrix.cpp
+++ b/LED_Matrix/lib/Matrix/S_PWM/matrix.cpp
@@ -47,9 +47,9 @@ namespace Matrix {
         for (int i = 0; i < 8; i++) {
             gpio_init(i + 8);
             gpio_set_dir(i + 8, GPIO_OUT);
-        }
-        for (int i = 0; i < 8; i++)
             gpio_set_function(i + 8, GPIO_FUNC_PIO0);
+        }
+        
         gpio_init(22);
         gpio_set_dir(22, GPIO_OUT);
         gpio_clr_mask(0x40FF00);

--- a/LED_Matrix/lib/Matrix/S_PWM/worker.cpp
+++ b/LED_Matrix/lib/Matrix/S_PWM/worker.cpp
@@ -107,7 +107,7 @@ namespace Matrix::Worker {
     static void process(uint32_t val) {
         uint32_t upper_val, lower_val, temp;
 
-        // Smothing function (This is mostly magic!)
+        // Smoothing function (This is mostly magic!)
         val *= (1 << PWM_bits) - (1 << upper_bits) + 1;
         val /= 1 << PWM_bits;
 

--- a/LED_Matrix/lib/Matrix/S_PWM/worker.cpp
+++ b/LED_Matrix/lib/Matrix/S_PWM/worker.cpp
@@ -64,9 +64,8 @@ namespace Matrix::Worker {
             for (uint32_t y = last / 2; y < places; y += x) {
                 if (last != 0) {
                     if ((cntr % 2) == 0) {
-                        if (index == place) {
+                        if (index == place)
                             return y;
-                        }
 
                         index++;
                     }
@@ -74,9 +73,8 @@ namespace Matrix::Worker {
                     cntr++;
                 }
                 else {
-                    if (index == place) {
+                    if (index == place)
                         return y;
-                    }
 
                     index++;
                 }
@@ -91,17 +89,13 @@ namespace Matrix::Worker {
     static void store(uint32_t i, uint32_t val, uint32_t index) {
         uint32_t j;
 
-        for (j = 0; j < val && j < (1 << lower_bits); j++) {
-            for (uint8_t k = 0; k < 6; k++) {
+        for (j = 0; j < val && j < (1 << lower_bits); j++)
+            for (uint8_t k = 0; k < 6; k++)
                 index_table.table2[i][k][index][j] = 1 << k;
-            }
-        }
 
-        for (j = val; j < (1 << lower_bits); j++) {
-            for (uint8_t k = 0; k < 6; k++) {
+        for (j = val; j < (1 << lower_bits); j++)
+            for (uint8_t k = 0; k < 6; k++)
                 index_table.table2[i][k][index][j] = 0;
-            }
-        }
     }
 
     static void process(uint32_t val) {
@@ -118,19 +112,16 @@ namespace Matrix::Worker {
             temp = upper_val * (1 << (lower_bits - upper_bits));
             temp += lower_val / (1 << upper_bits);
 
-            if ((int32_t) val - (int32_t) (temp * (1 << upper_bits) + i) > 0) {
+            if ((int32_t) val - (int32_t) (temp * (1 << upper_bits) + i) > 0)
                 store(val, temp + 1, remap(i, 1 << upper_bits));
-            }
-            else {
+            else
                 store(val, temp, remap(i, 1 << upper_bits));
-            }
         }
     }
 
     static void build_index_table() {
-        for (uint32_t i = 0; i < (1 << PWM_bits); i++) {
+        for (uint32_t i = 0; i < (1 << PWM_bits); i++)
             process(i);
-        }
     }
 
     static void __not_in_flash_func(process_packet)(Serial::packet *p) {

--- a/LED_Matrix/lib/Matrix/S_PWM/worker.cpp
+++ b/LED_Matrix/lib/Matrix/S_PWM/worker.cpp
@@ -55,7 +55,7 @@ namespace Matrix::Worker {
         }
     }
 
-    static uint8_t remap(uint8_t place, uint8_t places) {
+    constexpr static uint8_t remap(uint8_t place, uint8_t places) {
         uint32_t last = 0;
         uint8_t index = 0;
         
@@ -86,8 +86,8 @@ namespace Matrix::Worker {
         return 0;
     }
 
-    static void store(uint32_t i, uint32_t val, uint32_t index) {
-        uint32_t j;
+    constexpr static void store(uint32_t i, uint32_t val, uint32_t index) {
+        uint32_t j = 0;
 
         for (j = 0; j < val && j < (1 << lower_bits); j++)
             for (uint8_t k = 0; k < 6; k++)
@@ -98,8 +98,10 @@ namespace Matrix::Worker {
                 index_table.table2[i][k][index][j] = 0;
     }
 
-    static void process(uint32_t val) {
-        uint32_t upper_val, lower_val, temp;
+    constexpr static void process(uint32_t val) {
+        uint32_t upper_val = 0;
+        uint32_t lower_val = 0;
+        uint32_t temp = 0;
 
         // Smoothing function (This is mostly magic!)
         val *= (1 << PWM_bits) - (1 << upper_bits) + 1;
@@ -119,7 +121,7 @@ namespace Matrix::Worker {
         }
     }
 
-    static void build_index_table() {
+    constexpr static void build_index_table() {
         for (uint32_t i = 0; i < (1 << PWM_bits); i++)
             process(i);
     }

--- a/LED_Matrix/lib/Matrix/S_PWM/worker.cpp
+++ b/LED_Matrix/lib/Matrix/S_PWM/worker.cpp
@@ -1,0 +1,113 @@
+/* 
+ * File:   worker.cpp
+ * Author: David Thacher
+ * License: GPL 3.0
+ */
+ 
+#include <algorithm>
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include "pico/multicore.h"
+#include "Serial/config.h"
+#include "Matrix/matrix.h"
+#include "Matrix/S_PWM/memory_format.h"
+#include "Matrix/helper.h"
+
+namespace Matrix {
+    extern test2 buf[];
+}
+
+namespace Matrix::Worker {
+    static uint8_t bank = 1;
+    volatile bool vsync = false;
+
+    union index_table_t {
+        uint8_t table[1 << PWM_bits][6][1 << PWM_bits];
+        uint8_t table2[1 << PWM_bits][6][1 << (PWM_bits - S_PWM_SEG)][1 << S_PWM_SEG];
+        uint32_t v[(1 << PWM_bits) * 6 * (1 << PWM_bits) / 4];
+    };
+
+    static index_table_t index_table;
+
+    static uint8_t *__not_in_flash_func(get_table)(uint16_t v, uint8_t i) {
+        constexpr uint32_t div = std::max((uint32_t) Serial::range_high / 1 << PWM_bits, (uint32_t) 1);
+        constexpr uint32_t mul = std::max((uint32_t) 1 << PWM_bits / Serial::range_high, (uint32_t) 1);
+
+        v = v * mul / div;
+        //v %= (1 << PWM_bits);
+        return index_table.table[v][i];
+    }
+
+    // Forgive the shameless and reckless casting.
+    template <typename T> static void __not_in_flash_func(set_pixel)(uint8_t x, uint8_t y, uint16_t r0, uint16_t g0, uint16_t b0, uint16_t r1, uint16_t g1, uint16_t b1) {    
+        T *c[6] = { (T *) get_table(r0, 0), (T *) get_table(g0, 1), (T *) get_table(b0, 2), (T *) get_table(r1, 3), (T *) get_table(g1, 4), (T *) get_table(b1, 5) };
+    
+        for (uint32_t i = 0; i < (1 << PWM_bits); i += sizeof(T)) {
+            T p = *c[0] + *c[1] + *c[2] + *c[3] + *c[4] + *c[5];
+
+            for (uint32_t k = 0; k < (1 << (PWM_bits - S_PWM_SEG)); k++)
+                for (uint32_t j = 0; (j < sizeof(T)) && ((i + j) < (1 << S_PWM_SEG)); j++)
+                    Matrix::buf[bank][y][k][i + j][x + 1] = (p >> (j * 8)) & 0xFF;
+
+            for (uint32_t j = 0; j < 6; j++)
+                ++c[j];
+        }
+    }
+
+    // TODO: Update to use table2
+    static void build_index_table() {
+        for (uint32_t i = 0; i < (1 << PWM_bits); i++) {
+            uint32_t j;
+            for (j = 0; j < i; j++)
+                for (uint8_t k = 0; k < 6; k++)
+                    index_table.table[i][k][j] = 1 << k;
+            for (j = i; j < (1 << PWM_bits); j++)
+                for (uint8_t k = 0; k < 6; k++)
+                    index_table.table[i][k][j] = 0;
+        }
+    }
+
+    static void __not_in_flash_func(process_packet)(Serial::packet *p) {
+        for (uint8_t y = 0; y < MULTIPLEX; y++) {
+            for (uint16_t x = 0; x < COLUMNS; x++) {
+
+                // Compiler should remove all but one of these.
+                switch ((1 << S_PWM_SEG) % 4) {
+                    case 0:
+                        set_pixel<uint32_t>(x, y, p->data[y][x].red, p->data[y][x].green, p->data[y][x].blue, p->data[y + MULTIPLEX][x].red, p->data[y + MULTIPLEX][x].green, p->data[y + MULTIPLEX][x].blue);
+                        break;
+                    case 2:
+                        set_pixel<uint16_t>(x, y, p->data[y][x].red, p->data[y][x].green, p->data[y][x].blue, p->data[y + MULTIPLEX][x].red, p->data[y + MULTIPLEX][x].green, p->data[y + MULTIPLEX][x].blue);
+                        break;
+                    default:
+                        set_pixel<uint8_t>(x, y, p->data[y][x].red, p->data[y][x].green, p->data[y][x].blue, p->data[y + MULTIPLEX][x].red, p->data[y + MULTIPLEX][x].green, p->data[y + MULTIPLEX][x].blue);
+                        break;
+                }
+            }
+        }
+        
+        if (!vsync) {
+            bank = (bank + 1) % 3;
+            vsync = true;
+        }
+    }
+
+    void __not_in_flash_func(work)() {
+        build_index_table();
+        
+        while(1) {
+            Serial::packet *p = (Serial::packet *) APP::multicore_fifo_pop_blocking_inline();
+            process_packet(p);
+        }
+    }
+
+    bool __not_in_flash_func(process)(void *arg, bool block) {
+        if (multicore_fifo_wready() || block) {
+            APP::multicore_fifo_push_blocking_inline((uint32_t) arg);
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/LED_Matrix/lib/Matrix/S_PWM/worker.cpp
+++ b/LED_Matrix/lib/Matrix/S_PWM/worker.cpp
@@ -88,24 +88,20 @@ namespace Matrix::Worker {
         return 0;
     }
 
-    static void store(uint32_t val, uint32_t index) {
-        /*
+    static void store(uint32_t i, uint32_t val, uint32_t index) {
         uint32_t j;
 
-            for (j = 0; j < i; j++) {
-                for (uint8_t k = 0; k < 6; k++) {
-
-                    index_table.table2[i][k][j / (1 << S_PWM_SEG)][j % (1 << S_PWM_SEG)] = 1 << k;
-                }
+        for (j = 0; j < val && j < (1 << lower_bits); j++) {
+            for (uint8_t k = 0; k < 6; k++) {
+                index_table.table2[i][k][index][j] = 1 << k;
             }
+        }
 
-            for (j = i; j < (1 << PWM_bits); j++) {
-                for (uint8_t k = 0; k < 6; k++) {
-
-                    index_table.table2[i][k][j / (1 << S_PWM_SEG)][j % (1 << S_PWM_SEG)] = 0;
-                }
+        for (j = val; j < (1 << lower_bits); j++) {
+            for (uint8_t k = 0; k < 6; k++) {
+                index_table.table2[i][k][index][j] = 0;
             }
-            */
+        }
     }
 
     static void process(uint32_t val) {
@@ -123,10 +119,10 @@ namespace Matrix::Worker {
             temp += lower_val / (1 << upper_bits);
 
             if ((int32_t) val - (int32_t) (temp * (1 << upper_bits) + i) > 0) {
-                store(temp + 1, remap(i, 1 << upper_bits));
+                store(val, temp + 1, remap(i, 1 << upper_bits));
             }
             else {
-                store(temp, remap(i, 1 << upper_bits));
+                store(val, temp, remap(i, 1 << upper_bits));
             }
         }
     }

--- a/LED_Matrix/src/CMakeLists.txt
+++ b/LED_Matrix/src/CMakeLists.txt
@@ -28,7 +28,7 @@ target_compile_definitions(led PRIVATE
     PICO_XOSC_STARTUP_DELAY_MULTIPLIER=64
 )
 
-pico_set_binary_type(led copy_to_ram)
+#pico_set_binary_type(led copy_to_ram)
 
 # enable usb output, disable uart output
 pico_enable_stdio_usb(led 1)

--- a/LED_Matrix/src/CMakeLists.txt
+++ b/LED_Matrix/src/CMakeLists.txt
@@ -28,7 +28,7 @@ target_compile_definitions(led PRIVATE
     PICO_XOSC_STARTUP_DELAY_MULTIPLIER=64
 )
 
-#pico_set_binary_type(led copy_to_ram)
+pico_set_binary_type(led copy_to_ram)
 
 # enable usb output, disable uart output
 pico_enable_stdio_usb(led 1)


### PR DESCRIPTION
This allows more PWM bits at lower refresh rates. Note these bits flicker but are not nearly as bright and therefore may not be as noticeable. This feature is experimental and only useful for 16x32 panels for the most part. RAM usage is very high and this may limit serial algorithms and future development significantly.